### PR TITLE
Issue 18: Rename the classes to remove YAML from Ansible

### DIFF
--- a/ansible_collections/ds/ansible_ds/playbooks/roles/dsserver/README.md
+++ b/ansible_collections/ds/ansible_ds/playbooks/roles/dsserver/README.md
@@ -171,10 +171,10 @@ dsserver_prefix | the directory server installation prefix (default is '') | no
 
 Variable tree description
 -------------------------
-  - instances: A list of <class 'module_utils.dsentities.YAMLInstance'>
-      - backends: A list of <class 'module_utils.dsentities.YAMLBackend'>
-          - agmts: A list of <class 'module_utils.dsentities.YAMLAgmt'>
-          - indexes: A list of <class 'module_utils.dsentities.YAMLIndex'>
+  - instances: A list of <class 'module_utils.dsentities.ConfigInstance'>
+      - backends: A list of <class 'module_utils.dsentities.ConfigBackend'>
+          - agmts: A list of <class 'module_utils.dsentities.ConfigAgmt'>
+          - indexes: A list of <class 'module_utils.dsentities.ConfigIndex'>
 
 # Options per entities
 

--- a/ansible_collections/ds/ansible_ds/plugins/module_utils/dsutil.py
+++ b/ansible_collections/ds/ansible_ds/plugins/module_utils/dsutil.py
@@ -158,30 +158,8 @@ def search_ext_s(inst, *args, **kwargs):
     return _ldap_op_s(inst, inst.search_ext_s, 'search_ext_s', *args, **kwargs)
 
 
-def toAnsibleResult(object):
-   cb=getattr(object, "toAnsibleResult", None)
-   if cb is not None:
-        return cb(object)
-   if isinstance(object, yaml.YAMLObject):
-        log.debug(f"toAnsibleResult: object={object}")
-        return toAnsibleResult( { 'tag':object.yaml_tag,  **object.__getstate__() } )
-   if type(object) is list:
-        l=[]
-        for i in object:
-            l.append(toAnsibleResult(i))
-        return l
-   if type(object) is tuple:
-        return tuple(toAnsibleResult(list(object)))
-   if type(object) is dict:
-        d={}
-        for k,v in object.items():
-            d[toAnsibleResult(k)] = toAnsibleResult(v)
-        return d
-   return object
-
-
 @dataclass
-class NormalizedDict(dict, yaml.YAMLObject):
+class NormalizedDict(dict):
     """
         A dict with normalized key stored in hash table 
         Note: The original version of the key (or the first one
@@ -280,7 +258,7 @@ class NormalizedDict(dict, yaml.YAMLObject):
 #values()       Returns a list of all the values in the dictionary
 #
 
-class LdapOp(yaml.YAMLObject):
+class LdapOp():
     """
         A dict with normalized key  stored in hash table
         Note: The original version of the key (or the first one

--- a/ansible_collections/ds/ansible_ds/plugins/modules/ds_info.py
+++ b/ansible_collections/ds/ansible_ds/plugins/modules/ds_info.py
@@ -166,11 +166,11 @@ import traceback
 
 if __name__ == "__main__":
     sys.path += [str(Path(__file__).parent.parent)]
-    from module_utils.dsentities import Option, DSEOption, ConfigOption, SpecialOption, OptionAction, MyYAMLObject, YAMLRoot, YAMLInstance, YAMLBackend, YAMLIndex
-    from module_utils.dsutil import setLogger, getLogger, log, toAnsibleResult
+    from module_utils.dsentities import Option, DSEOption, ConfigOption, SpecialOption, OptionAction, MyConfigObject, ConfigRoot, ConfigInstance, ConfigBackend, ConfigIndex, toAnsibleResult
+    from module_utils.dsutil import setLogger, getLogger, log
 else:
-    from ansible_collections.ds.ansible_ds.plugins.module_utils.dsentities import Option, DSEOption, ConfigOption, SpecialOption, OptionAction, MyYAMLObject, YAMLRoot, YAMLInstance, YAMLBackend, YAMLIndex
-    from ansible_collections.ds.ansible_ds.plugins.module_utils.dsutil import setLogger, getLogger, log, toAnsibleResult
+    from ansible_collections.ds.ansible_ds.plugins.module_utils.dsentities import Option, DSEOption, ConfigOption, SpecialOption, OptionAction, MyConfigObject, ConfigRoot, ConfigInstance, ConfigBackend, ConfigIndex, toAnsibleResult
+    from ansible_collections.ds.ansible_ds.plugins.module_utils.dsutil import setLogger, getLogger, log
 
 
 
@@ -224,7 +224,7 @@ def run_module():
 
     ### Create the main "Host" node containing this host instances
     try:
-        dsroot = YAMLRoot()
+        dsroot = ConfigRoot()
         dsroot.getFacts()
     except Exception as e:
         print(traceback.format_exc(), file=sys.stderr)

--- a/ansible_collections/ds/ansible_ds/plugins/modules/ds_server.py
+++ b/ansible_collections/ds/ansible_ds/plugins/modules/ds_server.py
@@ -165,13 +165,13 @@ import argparse
 # import the collection module_utils modules.
 if __name__ == "__main__":
     sys.path += [str(Path(__file__).parent.parent)]
-    from module_utils.dsentities import YAMLRoot
+    from module_utils.dsentities import ConfigRoot
     from module_utils.dsutil import setLogger, getLogger, log
-    from module_utils.dsutil import setLogger, getLogger, log, toAnsibleResult
+    from module_utils.dsutil import setLogger, getLogger, log
     from module_utils.dsentities_options import CONTENT_OPTIONS
 else:
-    from ansible_collections.ds.ansible_ds.plugins.module_utils.dsentities import YAMLRoot
-    from ansible_collections.ds.ansible_ds.plugins.module_utils.dsutil import setLogger, getLogger, log, toAnsibleResult
+    from ansible_collections.ds.ansible_ds.plugins.module_utils.dsentities import ConfigRoot
+    from ansible_collections.ds.ansible_ds.plugins.module_utils.dsutil import setLogger, getLogger, log
     from ansible_collections.ds.ansible_ds.plugins.module_utils.dsentities_options import CONTENT_OPTIONS
 
 
@@ -215,15 +215,15 @@ def run_module():
     path = module.params['path']
     content = module.params['content']
 
-    # Validate the parameter and get a YAMLRoot object
+    # Validate the parameter and get a ConfigRoot object
     c="{}"
     try:
         if path:
-            wanted_state = YAMLRoot.from_path(path)
+            wanted_state = ConfigRoot.from_path(path)
         elif content:
-            wanted_state = YAMLRoot.from_content(content)
+            wanted_state = ConfigRoot.from_content(content)
         else:
-            wanted_state = YAMLRoot.from_stdin()
+            wanted_state = ConfigRoot.from_stdin()
     except Exception as e:
         raise e
         module.fail_json(f'Failed to validate the parameters. error is {e}')
@@ -231,7 +231,7 @@ def run_module():
 
     log.debug(f"wanted_state={wanted_state}")
     # Determine current state
-    host = YAMLRoot()
+    host = ConfigRoot()
     host.getFacts()
     # Then change it
     summary = []

--- a/utils/gendoc.py
+++ b/utils/gendoc.py
@@ -23,7 +23,7 @@ from inspect import cleandoc
 p = str(Path(__file__).parent.parent)
 
 sys.path += ( f"{p}/ansible_collections/ds/ansible_ds/plugins", )
-from module_utils.dsentities import YAMLRoot
+from module_utils.dsentities import ConfigRoot
 from module_utils.dsutil import setLogger, getLogger, log
 
 class Doc:
@@ -190,7 +190,7 @@ class Doc:
     def generate(self, tab):
         # Generate ansible option doc from module classes
         print(cleandoc(self.header))
-        self.walk_entity(YAMLRoot, tab + self.tab)
+        self.walk_entity(ConfigRoot, tab + self.tab)
         print(cleandoc(self.footer))
 
 class Spec(Doc):
@@ -281,7 +281,7 @@ class Desc(Doc):
     """ Generation entity tree and options table in human readable markdown format """
 
     def classname(nclass):
-        res = re.match(".*YAML([^']*)", str(nclass))
+        res = re.match(".*Config([^']*)", str(nclass))
         return res.group(1).strip()
 
     def __init__(self, fout=sys.stdout):
@@ -321,13 +321,13 @@ class Desc(Doc):
         self.silent = True
         self.print("# Entities tree\n - Root")
         self.silent = False
-        self.walk_entity(YAMLRoot, tab + self.tab, actionOption=None, actionEntity=self.printEntity)
+        self.walk_entity(ConfigRoot, tab + self.tab, actionOption=None, actionEntity=self.printEntity)
         self.print("\n# Options per entities")
         self.silent = True 
         self.print("## Root")
         self.print("| Option | Required | Type | Description | Comment |")
         self.print("| - | - | - | - | - |")
-        self.walk_entity(YAMLRoot, tab + self.tab, actionOption=self.printOptions, actionEntity=self.printEntityHeader)
+        self.walk_entity(ConfigRoot, tab + self.tab, actionOption=self.printOptions, actionEntity=self.printEntityHeader)
 
 
 

--- a/utils/json2yaml.py
+++ b/utils/json2yaml.py
@@ -33,31 +33,31 @@ class MyYamlObject(dict, yaml.YAMLObject):
         self.__dict__ = d
         d.pop('tag')
 
-class YAMLRoot(MyYamlObject):
+class ConfigRoot(MyYamlObject):
     yaml_tag = u'!ds389Host'
 
-class YAMLInstance(MyYamlObject):
+class ConfigInstance(MyYamlObject):
     yaml_tag = u'!ds389Instance'
 
-class YAMLBackend(MyYamlObject):
+class ConfigBackend(MyYamlObject):
     yaml_tag = u'!ds389Backend'
 
-class YAMLIndex(MyYamlObject):
+class ConfigIndex(MyYamlObject):
     yaml_tag = u'!ds389Index'
 
 entities = { u'tag:yaml.org,2002:map' : MyYamlObject,
-             u'!ds389Host' : YAMLRoot ,
-             u'!ds389Instance' : YAMLInstance,
-             u'!ds389Backend' : YAMLBackend,
-             u'!ds389Index' : YAMLIndex
+             u'!ds389Host' : ConfigRoot ,
+             u'!ds389Instance' : ConfigInstance,
+             u'!ds389Backend' : ConfigBackend,
+             u'!ds389Index' : ConfigIndex
            }
 
-# end of YAML entities definition
+# end of Config entities definition
 
 # Callback to compute object classes from json
 def hook(d):
     if isinstance(d, dict):
-        # handle YAML entities
+        # handle Config entities
         if 'tag' in d and  d['tag'] in entities:
             return entities[d['tag']](d)
         # Handle fact result

--- a/utils/yaml2json.py
+++ b/utils/yaml2json.py
@@ -31,16 +31,16 @@ class MyClassObject(yaml.YAMLObject):
             dict[key] = val
         return dict
 
-class YAMLHost(MyClassObject):
+class ConfigHost(MyClassObject):
     yaml_tag = u'!ds389Host'
 
-class YAMLInstance(MyClassObject):
+class ConfigInstance(MyClassObject):
     yaml_tag = u'!ds389Instance'
 
-class YAMLBackend(MyClassObject):
+class ConfigBackend(MyClassObject):
     yaml_tag = u'!ds389Backend'
 
-class YAMLIndex(MyClassObject):
+class ConfigIndex(MyClassObject):
     yaml_tag = u'!ds389Index'
 
 class MyJsonEncoder(json.JSONEncoder):


### PR DESCRIPTION
As discussed in yesterday meeting, 
 The module classname should not be yaml.Object subclass nor contain YAML
  ( It was needed in first versions but now we relies on Ansible framework to convert the data) 
  Replaced YAML by Config in the classname and they are no more subclasses of yaml.Object

Issue: 18

Reviewed by: