### PR TITLE
Issue 25 - improve / fix python and ansible lint tests

### DIFF
--- a/.github/scripts/generate_matrix.py
+++ b/.github/scripts/generate_matrix.py
@@ -1,3 +1,5 @@
+"""Generates the github pytest test files matrix."""
+
 import os
 import sys
 import glob
@@ -5,9 +7,10 @@ import json
 from pathlib import Path
 
 wsdir = Path(__file__).parents[2]
-tcdir = glob.glob(f"{wsdir}/ansible_collections/*/*/tests")[0];
+tcdir = glob.glob(f"{wsdir}/ansible_collections/*/*/tests")[0]
 
-def isTestCase(strpath, include_dirs=False):
+def is_testcase(strpath, include_dirs=False):
+    """Tells whether the path is a testcase."""
     path = Path(os.path.join(tcdir,strpath))
     if path.is_symlink():
         return False
@@ -25,7 +28,7 @@ if len(sys.argv) > 1:
     valid_suites = []
     # Validate if the path is a valid file or directory with files
     for suite in suites:
-        if isTestCase(suite, include_dirs=True):
+        if is_testcase(suite, include_dirs=True):
             valid_suites.append(suite)
     suites = valid_suites
 
@@ -33,7 +36,7 @@ else:
     # Use tests from the source
     suites = []
     for file in glob.glob("[a-z]*/**/*.[py]*", recursive=True, root_dir=tcdir):
-        if isTestCase(file):
+        if is_testcase(file):
             suites.append(file)
     suites.sort()
 
@@ -41,4 +44,3 @@ suites_list = [{ "suite": suite} for suite in suites]
 matrix = {"include": suites_list}
 
 print(json.dumps(matrix))
-

--- a/.github/workflows/utest.yml
+++ b/.github/workflows/utest.yml
@@ -34,7 +34,7 @@ jobs:
 
       - name: Get a list of all test suites
         id: set-matrix
-        run: echo "::set-output name=matrix::$(python3 .github/scripts/generate_matrix.py ${{ github.event.inputs.pytest_tests }})"
+        run: echo "matrix=$(python3 .github/scripts/generate_matrix.py ${{ github.event.inputs.pytest_tests }})" >>$GITHUB_OUTPUT
 
       - name: Install base software
         run: dnf install -y python3-lib389 ansible
@@ -46,7 +46,7 @@ jobs:
         run: make
 
       - name: Upload Ansible collection
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: ansible_ds
           path: ansible_ds.tgz
@@ -105,7 +105,7 @@ jobs:
 
     - name: Upload pytest test results
       if: always()
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: pytest-${{ env.PYTEST_SUITE }}
         path: |

--- a/.pylintrc
+++ b/.pylintrc
@@ -1,0 +1,12 @@
+[MESSAGES CONTROL]
+# R0022 is needed because we have to handles different pytest versions with different method prototypes
+# E0401 (import-error) because we need custom sys.path 
+# C0413 (wrong-import-position) because sometime the sys.path must be set before the import
+disable=R0022,E0401,C0413
+
+
+[FORMAT]
+max-attributes=11
+max-line-length=130
+ignore-long-lines=^\s.*Option.*$
+method-naming-style=camelCase

--- a/Makefile
+++ b/Makefile
@@ -41,14 +41,13 @@ prereq:
 	pip3 install -r requirements.txt
 
 lint:
-	cd ansible_collections/ds389/ansible_ds/tests; pylint --disable=R0022 --max-line-length=130 '--ignore-long-lines=^\s.*Option.*$$' --method-naming-style=camelCase $$(find . -name '*.py')
-	#pylint --max-line-length=130 '--ignore-long-lines=^\s.*Option.*$$' --method-naming-style=camelCase --recursive=y .
-	#cd ansible_collections/ds389/ansible_ds/tests; py.test --pylint
+    # Lets exclude the plugins code until we have done a code cleanup
+	pylint --rcfile $(PWD)/.pylintrc $$(find . -name '*.py' | grep -v plugins)
 
 github_pylint: lint
 
 github_anlint:
-	ansible-lint
+	cd $(HOME)/.ansible && ansible-lint
 
 github_utest:
 	pytest-3 -vvvvv ansible_collections/$N/$M/tests

--- a/utils/gendoc.py
+++ b/utils/gendoc.py
@@ -8,25 +8,72 @@
 # --- END COPYRIGHT BLOCK ---
 #
 
-###### GENERATE DOC FRAGMENT ###########
-# Usage:  python gendoc.py doc  Generate the doc fragment about ds389_server options
-# Usage:  python gendoc.py spec  Generate the python file with the ansible parameter
-#                                specification for ds389_server module
 
-import os
+"""This module parse dsentities_options.py to generate different files:
+    Usage:  python gendoc.py doc    Generate the doc fragment about ds389_server options.
+            python gendoc.py spec   Generate the python file with the ansible parameters
+                                    specification for ds_server module.
+            python gendoc.py desc   Generate human readable markdown file containing
+                                    the entities tree and options table
+            python gendoc.py readme	Generate the playbook readme.
+"""
+
 import re
 import glob
 import sys
+from abc import ABC, abstractmethod
 from pathlib import Path
 from inspect import cleandoc
 
-p = str(Path(__file__).parent.parent)
+WORKSPACE_DIR = str(Path(__file__).parent.parent)
 
-sys.path += ( f"{p}/ansible_collections/ds389/ansible_ds/plugins", )
+sys.path += ( f"{WORKSPACE_DIR}/ansible_collections/ds389/ansible_ds/plugins", )
 from module_utils.ds389_entities import ConfigRoot
-from module_utils.ds389_util import setLogger, getLogger, log
+from module_utils.ds389_util import setLogger
 
-class Doc:
+class AbstractAnsibleDsParser(ABC):
+    """Abstract class to avoid pylint error about unused arguments."""
+
+    @abstractmethod
+    def printItem(self, item, tab):
+        """Print a line about single data."""
+
+    @abstractmethod
+    def printChoices(self, choices, tab):
+        """Print lines to describe a choice."""
+
+    @abstractmethod
+    def printMeta(self, entity, tab):
+        """Print lines about entity metadata."""
+
+    #def sortOptions(self, keys):
+    #def printActionOption(self, option, tab):
+    #def printActionEntity(self, name, nclass, tab):
+
+    @abstractmethod
+    def printMsg(self, msg):
+        """Print a single data."""
+
+    @abstractmethod
+    def print(self, key, item, tab, skip=False):
+        """Print a line about key+value."""
+
+    @abstractmethod
+    def sortOptions(self, keys):
+        """Sort helper."""
+
+    @abstractmethod
+    def walkEntity(self, oclass, tab, action_option="default", action_entity="default"):
+        """The dsentities_options.py entity parser."""
+
+    @abstractmethod
+    def generate(self, tab):
+        """Generate ansible option doc from module classes."""
+
+
+
+class Doc(AbstractAnsibleDsParser):
+    """This class contains the source parser and initialize its members to generate the doc fragment."""
     STATE_DESC = """'state' option determines how the other option are handled:
                      If 'present' then specified options are added.
                      If 'absent' then specified options are removed.
@@ -76,126 +123,134 @@ class Doc:
 
         self.footer = '"""'
         self.tab = "  "
-        self.sd = None
-        self.ed = None
-        self.sl = None
-        self.el = None
+        self.start_dict = None
+        self.end_dict = None
+        self.start_list = None
+        self.end_list = None
         self.suboptions = "suboptions"
         setLogger(__file__, None)
 
-    def prt(self, key, item, tab, skip=False):
+    def print(self, key, item, tab, skip=False):
         if item is None:
             if not skip:
                 print(f"{tab}{key}:")
         else:
             print(f"{tab}{key}: {item}")
 
-    def prt_item(self, item, tab):
+    def printItem(self, item, tab):
+        """Print a line about single data."""
         if item:
             print(f"{tab}{item}")
 
-    def prt_choices(self, choices, tab):
-        for v in choices:
-            print(f"{tab} - {v}")
+    def printChoices(self, choices, tab):
+        for val in choices:
+            print(f"{tab} - {val}")
 
-    def prt_meta(self, entity, tab):
-        pass
+    def printMsg(self, msg):
+        """Print a single data."""
 
-    def sortweight(self, option):
-        if option.name in ('name', 'state'):
-            res = 'A'
-        else:
-            res = 'B'
-        if option.required:
-            res += 'C'
-        else:
-            res += 'D'
-        res += option.name
-        return res
+    def printMeta(self, entity, tab):
+        """Print lines about entity metadata."""
 
     def sortOptions(self, keys):
-        s = sorted( [ (self.sortweight(key), key) for key in keys])
-        return [ k[1] for k in s ]
+        """Sort helper."""
 
-    def _actionOption(self, option, tab):
-        t1 = tab + self.tab
-        t2 = t1 + self.tab
-        t3 = t2 + self.tab
-        self.prt(option.name, self.sd, tab)
-        self.prt("description", f"{option.desc}.", t1)
-        self.prt("required", option.required, t1)
+        def sortweight(option):
+            if option.name in ('name', 'state'):
+                res = 'A'
+            else:
+                res = 'B'
+            if option.required:
+                res += 'C'
+            else:
+                res += 'D'
+            res += option.name
+            return res
+
+        sorted_list = sorted( [ (sortweight(key), key) for key in keys])
+        return [ k[1] for k in sorted_list ]
+
+    def printActionOption(self, option, tab):
+        """Hanles action options."""
+
+        tab1 = tab + self.tab
+        tab2 = tab1 + self.tab
+        self.print(option.name, self.start_dict, tab)
+        self.print("description", f"{option.desc}.", tab1)
+        self.print("required", option.required, tab1)
         vdef = getattr(option, "vdef", None)
         if vdef is not None:
-            self.prt("default", vdef, t1)
+            self.print("default", vdef, tab1)
         if option.choice:
-            self.prt("type", "str", t1)
-            self.prt("choices", self.sl, t1)
-            self.prt_choices(option.choice, t2)
-            self.prt_item(self.el, t1)
+            self.print("type", "str", tab1)
+            self.print("choices", self.start_list, tab1)
+            self.printChoices(option.choice, tab2)
+            self.printItem(self.end_list, tab1)
         else:
-            self.prt("type", option.type, t1)
-        self.prt_item(self.ed, tab)
-    
-    def _actionEntity(self, name, nclass, tab):
-        t1 = tab + self.tab
-        t2 = t1 + self.tab
-        t3 = t2 + self.tab
-        self.prt(name, self.sd, tab)
-        self.prt("description", f"List of {name} options.", t1)
-        self.prt("required", "False", t1)
-        self.prt("type", "list", t1)
-        self.prt("elements", "dict", t1)
-        self.prt(self.suboptions, self.sd, t1)
+            self.print("type", option.type, tab1)
+        self.printItem(self.end_dict, tab)
+
+    def printActionEntity(self, name, nclass, tab):
+        """Handles action entity."""
+        tab1 = tab + self.tab
+        tab2 = tab1 + self.tab
+        tab3 = tab2 + self.tab
+        self.print(name, self.start_dict, tab)
+        self.print("description", f"List of {name} options.", tab1)
+        self.print("required", "False", tab1)
+        self.print("type", "list", tab1)
+        self.print("elements", "dict", tab1)
+        self.print(self.suboptions, self.start_dict, tab1)
         if name == "indexes":
             desc = "index"
         else:
             desc = str(name[0:-1])
-        self.prt("name", self.sd, t2)
-        self.prt("description", f"{desc}'s name.", t3)
-        self.prt("type", "str", t3)
-        self.prt("required", "True", t3)
-        self.prt_item(self.ed, t2)
-        self.walk_entity(nclass, t2)
-        self.prt_item(self.ed, t1)
-        self.prt_item(self.ed, tab)
+        self.print("name", self.start_dict, tab2)
+        self.print("description", f"{desc}'s name.", tab3)
+        self.print("type", "str", tab3)
+        self.print("required", "True", tab3)
+        self.printItem(self.end_dict, tab2)
+        self.walkEntity(nclass, tab2)
+        self.printItem(self.end_dict, tab1)
+        self.printItem(self.end_dict, tab)
 
-    def walk_entity(self, oclass, tab, actionOption="default", actionEntity="default"):
-        t1 = tab + self.tab
-        t2 = t1 + self.tab
-        if actionOption == "default":
+    def walkEntity(self, oclass, tab, action_option="default", action_entity="default"):
+        tab1 = tab + self.tab
+        tab2 = tab1 + self.tab
+        if action_option == "default":
             # set default action
-            actionOption = self._actionOption
-        if actionEntity == "default":
+            action_option = self.printActionOption
+        if action_entity == "default":
             # set default action
-            actionEntity = self._actionEntity
-        if actionOption == "None":
+            action_entity = self.printActionEntity
+        if action_option == "None":
             # set no action
-            actionOption = None
-        if actionEntity == "None":
+            action_option = None
+        if action_entity == "None":
             # set no action
-            actionEntity = None
+            action_entity = None
         entity = oclass(name='foo')
-        if actionOption:
+        if action_option:
             for option in self.sortOptions(entity.OPTIONS):
-                actionOption(option, tab)
+                action_option(option, tab)
         for key in sorted(entity.CHILDREN.keys()):
             nclass = entity.CHILDREN[key]
-            if actionEntity:
-                actionEntity(key, nclass, tab)
+            if action_entity:
+                action_entity(key, nclass, tab)
             else:
-                self.walk_entity(nclass, t2, actionOption=actionOption, actionEntity=actionEntity)
-        self.prt_meta(entity, tab)
-
+                self.walkEntity(nclass, tab2, action_option=action_option, action_entity=action_entity)
+        self.printMeta(entity, tab)
 
     def generate(self, tab):
-        # Generate ansible option doc from module classes
         print(cleandoc(self.header))
-        self.walk_entity(ConfigRoot, tab + self.tab)
+        self.walkEntity(ConfigRoot, tab + self.tab)
         print(cleandoc(self.footer))
 
+
 class Spec(Doc):
+    """This class reuses the source parser from Doc class but initialize its member to generate the spec file."""
     def __init__(self):
-        super(Spec, self).__init__()
+        super().__init__()
         self.header = """#!/usr/bin/python3
 
 # --- BEGIN COPYRIGHT BLOCK ---
@@ -215,14 +270,14 @@ class Spec(Doc):
 CONTENT_OPTIONS = {"""
         self.footer = "}"
         self.tab = "    "
-        self.sd = "{"
-        self.ed = "},"
-        self.sl = "("
-        self.el = "),"
+        self.start_dict = "{"
+        self.end_dict = "},"
+        self.start_list = "("
+        self.end_list = "),"
         self.suboptions = "options"
-        self.dd = '"""'
+        self.doc_delim = '"""'
 
-    def prt(self, key, item, tab, skip=False):
+    def print(self, key, item, tab, skip=False):
         delim = {"\n", "'", '"'}
         if item is None:
             if not skip:
@@ -234,45 +289,51 @@ CONTENT_OPTIONS = {"""
         elif item in ("{", "(", "["):
             print(f"{tab}'{key}': {item}")
         elif not set(item).isdisjoint(delim):
-            print(f"{tab}'{key}': {self.dd}{item}{self.dd},")
+            print(f"{tab}'{key}': {self.doc_delim}{item}{self.doc_delim},")
         else:
             print(f"{tab}'{key}': '{item}',")
 
-    def prt_choices(self, choices, tab):
-        for v in choices:
-            print(f"{tab}'{v}',")
+    def printChoices(self, choices, tab):
+        for val in choices:
+            print(f"{tab}'{val}',")
 
-    def prt_meta(self, entity, tab):
-        t1 = tab + self.tab
-        for k,d in entity.OPTIONS_META.items():
-            self.prt(k, "[", tab)
-            for i in d:
-                print(f"{t1}{str(i)},")
+    def printMeta(self, entity, tab):
+        tab1 = tab + self.tab
+        for key,data in entity.OPTIONS_META.items():
+            self.print(key, "[", tab)
+            for val in data:
+                print(f"{tab1}{str(val)},")
             print(f"{tab}],")
 
 class Readme:
+    """This class contains the code to generate the playbook Readme file."""
     def __init__(self):
-        pass
+        self.template = f"{WORKSPACE_DIR}/ansible_collections/ds389/ansible_ds/**/*.tmpl"
+        self.encoding = 'utf-8'
 
     def cat(self, filename, fout):
-        with open(filename, 'r') as f:
-            for line in f:
+        """Concanates filename into fout file."""
+        with open(filename, 'r', encoding=self.encoding) as file:
+            for line in file:
                 fout.write(line)
 
     def parseLine(self, line, fout):
+        """Parse Readme template line and expands the varaible."""
         res = re.match('@@@INSERT *([^ ]*)', line)
         if res:
             name = res.group(1).strip()
-            self.cat(f'{p}/ansible_collections/ds389/ansible_ds/playbooks/{name}', fout)
+            self.cat(f'{WORKSPACE_DIR}/ansible_collections/ds389/ansible_ds/playbooks/{name}', fout)
         elif re.match('@@@DESC', line):
             Desc(fout).generate("")
         else:
             fout.write(line)
-            
+
     def generate(self):
-        for path in glob.iglob(f"{p}/ansible_collections/ds389/ansible_ds/**/*.tmpl", recursive=True):
-            with open(path, 'r') as fin:
-                with open(path.replace('tmpl', 'md'), 'w') as fout:
+        """Generate the readme file."""
+
+        for path in glob.iglob(self.template, recursive=True):
+            with open(path, 'r', encoding=self.encoding) as fin:
+                with open(path.replace('tmpl', 'md'), 'w', encoding=self.encoding) as fout:
                     for line in fin:
                         self.parseLine(line, fout)
 
@@ -280,64 +341,70 @@ class Readme:
 class Desc(Doc):
     """ Generation entity tree and options table in human readable markdown format """
 
+    @staticmethod
     def classname(nclass):
+        """Get object classname."""
         res = re.match(".*Config([^']*)", str(nclass))
         return res.group(1).strip()
 
     def __init__(self, fout=sys.stdout):
-        super(Desc, self).__init__()
+        super().__init__()
         self.fout = fout
         self.silent = False
 
-    def print(self, msg):
+    def printMsg(self, msg):
+        """Print a single data."""
         if not self.silent or self.fout == sys.stdout:
             print(msg, file=self.fout)
 
     def printEntity(self, name, nclass, tab):
-        t1 = tab + self.tab
-        t2 = t1 + self.tab
-        self.print(f"{tab}- {name}: A list of {nclass}")
-        self.walk_entity(nclass, t2, actionOption=None, actionEntity=self.printEntity)
+        """Print an entity."""
+        tab1 = tab + self.tab
+        tab2 = tab1 + self.tab
+        self.printMsg(f"{tab}- {name}: A list of {nclass}")
+        self.walkEntity(nclass, tab2, action_option=None, action_entity=self.printEntity)
 
-    def printEntityHeader(self, name, nclass, tab):
-        t1 = tab + self.tab
-        t2 = t1 + self.tab
+    def printEntityHeader(self, _name, nclass, tab):
+        """Print an entity header callback."""
+        tab1 = tab + self.tab
+        tab2 = tab1 + self.tab
         self.silent = False
-        self.print(f"\n## {Desc.classname(nclass)}")
-        self.print("| Option | Required | Type | Description | Comment |")
-        self.print("| - | -  | -  | -  | -  |")
-        self.walk_entity(nclass, t2, actionOption=self.printOptions, actionEntity=self.printEntityHeader)
+        self.printMsg(f"\n## {Desc.classname(nclass)}")
+        self.printMsg("| Option | Required | Type | Description | Comment |")
+        self.printMsg("| - | -  | -  | -  | -  |")
+        self.walkEntity(nclass, tab2, action_option=self.printOptions, action_entity=self.printEntityHeader)
 
-    def printOptions(self, option, tab):
+    def printOptions(self, option, _tab):
+        """Print an option callback."""
         comment = ""
         if option.choice:
             comment += f"Value may be one of: {option.choice}. "
         if option.vdef:
-            comment += f"Default value is: {option.vdef}." 
-        self.print(f"| {option.name} | {option.required} | {option.type} | {option.desc} | {comment} |")
+            comment += f"Default value is: {option.vdef}."
+        self.printMsg(f"| {option.name} | {option.required} | {option.type} | {option.desc} | {comment} |")
 
     def generate(self, tab):
-        # Generate ansible option doc from module classes
+        """Generate ansible option doc from module classes."""
         self.silent = True
-        self.print("# Entities tree\n - Root")
+        self.printMsg("# Entities tree\n - Root")
         self.silent = False
-        self.walk_entity(ConfigRoot, tab + self.tab, actionOption=None, actionEntity=self.printEntity)
-        self.print("\n# Options per entities")
-        self.silent = True 
-        self.print("## Root")
-        self.print("| Option | Required | Type | Description | Comment |")
-        self.print("| - | - | - | - | - |")
-        self.walk_entity(ConfigRoot, tab + self.tab, actionOption=self.printOptions, actionEntity=self.printEntityHeader)
+        self.walkEntity(ConfigRoot, tab + self.tab, action_option=None, action_entity=self.printEntity)
+        self.printMsg("\n# Options per entities")
+        self.silent = True
+        self.printMsg("## Root")
+        self.printMsg("| Option | Required | Type | Description | Comment |")
+        self.printMsg("| - | - | - | - | - |")
+        self.walkEntity(ConfigRoot, tab + self.tab, action_option=self.printOptions, action_entity=self.printEntityHeader)
 
 
 
 if "doc" in sys.argv:
-	Doc().generate("")
+    Doc().generate("")
 elif "spec" in sys.argv:
-	Spec().generate("")
+    Spec().generate("")
 elif "desc" in sys.argv:
-	Desc().generate("")
+    Desc().generate("")
 elif "readme" in sys.argv:
-	Readme().generate()
+    Readme().generate()
 else:
     print("Usage: python gendoc.py doc|spec|readme|desc")

--- a/utils/json2yaml.py
+++ b/utils/json2yaml.py
@@ -8,71 +8,75 @@
 # --- END COPYRIGHT BLOCK ---
 #
 
-#
-# Usage: json2yaml.py json_file_path
-#  Generate a json_file_path.yml file containing the YAML
-#
-# Example: to collect ds state then replay then:
-#   echo '{ "ANSIBLE_MODULE_ARGS": { "prefix" : "'"$PREFIX"'" } }' | ds389_info.py > /tmp/o
-#   j2y.py /tmp/o
-#   dsupdate.py /tmp/o.yml
+"""Debugging tool used to convert yaml file to json.
+    Usage: json2yaml.py json_file_path
+    Generate a json_file_path.yml file containing the YAML
+
+    Example: to collect ds state then replay then:
+        echo '{ "ANSIBLE_MODULE_ARGS": { "prefix" : "'"$PREFIX"'" } }' | ds389_info.py > /tmp/o
+        json2yaml.py /tmp/o
+        dsupdate.py /tmp/o.yml
+"""
 
 
 import sys
-import os
 import json
 import yaml
 
-# Lets define the entities objects associated with YAML tags
-# Note that is just a placeholder so that YAML tags get rightly displayed.
 class MyYamlObject(dict, yaml.YAMLObject):
+    """Defines the entities objects associated with YAML tags.
+        Note: is just a placeholder so that YAML tags get rightly displayed.
+    """
+
     # handled normalized dict
-    yaml_tag = u'tag:yaml.org,2002:map'
+    yaml_tag = 'tag:yaml.org,2002:map'
 
     def __init__(self, d):
+        super().__init__()
         self.__dict__ = d
         d.pop('tag')
 
 class ConfigRoot(MyYamlObject):
-    yaml_tag = u'!ds389Host'
+    """The Host entity placeholder."""
+    yaml_tag = '!ds389Host'
 
 class ConfigInstance(MyYamlObject):
-    yaml_tag = u'!ds389Instance'
+    """The Instance entity placeholder."""
+    yaml_tag = '!ds389Instance'
 
 class ConfigBackend(MyYamlObject):
-    yaml_tag = u'!ds389Backend'
+    """The Backend entity placeholder."""
+    yaml_tag = '!ds389Backend'
 
 class ConfigIndex(MyYamlObject):
-    yaml_tag = u'!ds389Index'
+    """The Index entity placeholder."""
+    yaml_tag = '!ds389Index'
 
-entities = { u'tag:yaml.org,2002:map' : MyYamlObject,
-             u'!ds389Host' : ConfigRoot ,
-             u'!ds389Instance' : ConfigInstance,
-             u'!ds389Backend' : ConfigBackend,
-             u'!ds389Index' : ConfigIndex
+entities = { 'tag:yaml.org,2002:map' : MyYamlObject,
+             '!ds389Host' : ConfigRoot ,
+             '!ds389Instance' : ConfigInstance,
+             '!ds389Backend' : ConfigBackend,
+             '!ds389Index' : ConfigIndex
            }
 
 # end of Config entities definition
 
-# Callback to compute object classes from json
-def hook(d):
-    if isinstance(d, dict):
+def hook(_data):
+    """Callback to compute object classes from json."""
+    if isinstance(_data, dict):
         # handle Config entities
-        if 'tag' in d and  d['tag'] in entities:
-            return entities[d['tag']](d)
+        if 'tag' in _data and  _data['tag'] in entities:
+            return entities[_data['tag']](_data)
         # Handle fact result
-        if 'my_useful_info' in d:
-            return hook(d['my_useful_info'])
-    return d
+        if 'my_useful_info' in _data:
+            return hook(_data['my_useful_info'])
+    return data
 
 
-fin_name = sys.argv[1]
-fout_name = fin_name.replace('.json','') + '.yml'
-with open(fin_name, 'r') as fin:
-    data = json.load(fin, object_hook=hook)
-    with open(fout_name, 'w') as fout:
-        yaml.dump(data, fout, encoding='utf-8')
-print(f'{sys.argv[0]}: created {fout_name} file.')
-
-
-
+F_IN_NAME = sys.argv[1]
+F_OUT_NAME = F_IN_NAME.replace('.json','') + '.yml'
+with open(F_IN_NAME, 'r', encoding='utf-8') as f_in:
+    data = json.load(f_in, object_hook=hook)
+    with open(F_OUT_NAME, 'w', encoding='utf-8') as f_out:
+        yaml.dump(data, f_out, encoding='utf-8')
+print(f'{sys.argv[0]}: created {F_OUT_NAME} file.')

--- a/utils/yaml2json.py
+++ b/utils/yaml2json.py
@@ -8,60 +8,63 @@
 # --- END COPYRIGHT BLOCK ---
 #
 
-#
-# Usage: yaml2json.py yaml_file_path
-#  Generate a yaml_file_path.json file containing the JSON
-#
+"""Debugging tool used to convert json file to yaml.
+    Usage: yaml2json.py yaml_file_path
+           Generate a yaml_file_path.json file containing the JSON.
+"""
 
 import sys
-import os
 import json
 import yaml
 
-# Lets define the entities objects associated with YAML tags
-# Note that is just a placeholder so that YAML tags get rightly displayed.
-
 class MyClassObject(yaml.YAMLObject):
+    """Defines the entities objects associated with YAML tags.
+        Note: is just a placeholder so that YAML tags get rightly displayed.
+    """
+
     yaml_loader = yaml.SafeLoader
 
     def toObj(self):
-        dict = { "tag" : self.yaml_tag }
+        """Convert object into dict."""
+        _dict = { "tag" : self.yaml_tag }
         for key, val in self.__dict__.items():
             print(f"{key}->{val}")
-            dict[key] = val
-        return dict
+            _dict[key] = val
+        return _dict
 
 class ConfigHost(MyClassObject):
-    yaml_tag = u'!ds389Host'
+    """The Host entity placeholder."""
+    yaml_tag = '!ds389Host'
 
 class ConfigInstance(MyClassObject):
-    yaml_tag = u'!ds389Instance'
+    """The Instance entity placeholder."""
+    yaml_tag = '!ds389Instance'
 
 class ConfigBackend(MyClassObject):
-    yaml_tag = u'!ds389Backend'
+    """The Backend entity placeholder."""
+    yaml_tag = '!ds389Backend'
 
 class ConfigIndex(MyClassObject):
-    yaml_tag = u'!ds389Index'
+    """The Index entity placeholder."""
+    yaml_tag = '!ds389Index'
 
 class MyJsonEncoder(json.JSONEncoder):
-    def default(self, obj):
-        print(f"obj={obj}")
-        if isinstance(obj, MyClassObject):
-            return obj.toObj()
+    """A custom json encoder."""
+    def default(self, o):
+        print(f"obj={o}")
+        if isinstance(o, MyClassObject):
+            return o.toObj()
         # Let the base class default method raise the TypeError
-        return json.JSONEncoder.default(self, obj)
+        return json.JSONEncoder.default(self, o)
 
 
 
 
-fin_name = sys.argv[1]
-fout_name = fin_name.replace('.yml','') + '.json'
-with open(fin_name, 'r') as fin:
-    data = yaml.safe_load(fin)
+F_IN_NAME = sys.argv[1]
+F_OUT_NAME = F_IN_NAME.replace('.yml','') + '.json'
+with open(F_IN_NAME, 'r', encoding='utf-8') as f_in:
+    data = yaml.safe_load(f_in)
     print(f'data: {data}')
-    with open(fout_name, 'w') as fout:
-        fout.write(json.dumps(data, cls=MyJsonEncoder))
-print(f'{sys.argv[0]}: created {fout_name} file.')
-
-
-
+    with open(F_OUT_NAME, 'w', encoding='utf-8') as f_out:
+        f_out.write(json.dumps(data, cls=MyJsonEncoder))
+print(f'{sys.argv[0]}: created {F_OUT_NAME} file.')


### PR DESCRIPTION
Activated pylint on all python files except the collection modules that need a serious code cleanup.
Fixed pylint errors in the utils and .github/script folders.
Fixed the Makefile to run ansible-lint  in the ansible execution folder (i.e: $HOME/.ansible)
Fixed the deprecated warnings in github workflow code.

To be done later on in new issues: 
- Fix ansible lint errors
- Fix ansible lint warning
- python plugins code cleanup and reactivate pylint on these files.
- Fix same deprecated warnings in github 389ds workflow code

Issue #25 

Reviewed by: ?
