### PR TITLE
Issue 28 - Fix Ansible lint issues - Backup Role and Playbooks

### DIFF
--- a/.ansible-lint
+++ b/.ansible-lint
@@ -1,0 +1,18 @@
+---
+exclude_paths:
+  - .github/
+  - .pylintrc
+  - utils/
+
+parseable: true
+quiet: false
+use_default_rules: true
+verbosity: 1
+
+skip_list:
+  - '301'  # Commands should not change things if nothing needs doing'
+  - '305'  # Use shell only when shell functionality is required
+  - '306'  # risky-shell-pipe
+  - experimental   # Do not run any experimental tests
+  - name[template] # Allow Jinja templating inside task names
+

--- a/Makefile
+++ b/Makefile
@@ -47,7 +47,7 @@ lint:
 github_pylint: lint
 
 github_anlint:
-	cd $(HOME)/.ansible && ansible-lint
+	cd $(HOME)/.ansible && ansible-lint -c $(PWD)/.ansible-lint
 
 github_utest:
 	pytest-3 -vvvvv ansible_collections/$N/$M/tests

--- a/ansible_collections/ds389/ansible_ds/playbooks/backup_instance.yml
+++ b/ansible_collections/ds389/ansible_ds/playbooks/backup_instance.yml
@@ -4,5 +4,5 @@
   become: true
 
   roles:
-  - role: ds389_backup
-    state: present
+    - role: ds389_backup
+      state: present

--- a/ansible_collections/ds389/ansible_ds/playbooks/backup_instance_to_controller.yml
+++ b/ansible_collections/ds389/ansible_ds/playbooks/backup_instance_to_controller.yml
@@ -4,9 +4,9 @@
   become: true
 
   vars:
-    ds389_backup_to_controller: yes
-    # ds389_backup_keep_on_server: yes
+    ds389_backup_to_controller: true
+    # ds389_backup_keep_on_server: true
 
   roles:
-  - role: ds389_backup
-    state: present
+    - role: ds389_backup
+      state: present

--- a/ansible_collections/ds389/ansible_ds/playbooks/copy_all_backups_from_server.yml
+++ b/ansible_collections/ds389/ansible_ds/playbooks/copy_all_backups_from_server.yml
@@ -5,9 +5,8 @@
 
   vars:
     ds389_backup_name: all
-    ds389_backup_to_controller: yes
+    ds389_backup_to_controller: true
 
   roles:
-  - role: ds389_backup
-    state: copied
-    
+    - role: ds389_backup
+      state: copied

--- a/ansible_collections/ds389/ansible_ds/playbooks/copy_backup_from_controller.yml
+++ b/ansible_collections/ds389/ansible_ds/playbooks/copy_backup_from_controller.yml
@@ -5,8 +5,8 @@
 
   vars:
     ds389_backup_name: localhost.localdomain_localhost_2022_05_19_21_25_05
-    ds389_backup_from_controller: yes
+    ds389_backup_from_controller: true
 
   roles:
-  - role: ds389_backup
-    state: copied
+    - role: ds389_backup
+      state: copied

--- a/ansible_collections/ds389/ansible_ds/playbooks/copy_backup_from_server.yml
+++ b/ansible_collections/ds389/ansible_ds/playbooks/copy_backup_from_server.yml
@@ -5,8 +5,8 @@
 
   vars:
     ds389_backup_name: localhost_2022_05_19_21_25_05
-    ds389_backup_to_controller: yes
+    ds389_backup_to_controller: true
 
   roles:
-  - role: ds389_backup
-    state: copied
+    - role: ds389_backup
+      state: copied

--- a/ansible_collections/ds389/ansible_ds/playbooks/remove_all_backups_from_server.yml
+++ b/ansible_collections/ds389/ansible_ds/playbooks/remove_all_backups_from_server.yml
@@ -7,5 +7,5 @@
     ds389_backup_name: all
 
   roles:
-  - role: ds389_backup
-    state: absent
+    - role: ds389_backup
+      state: absent

--- a/ansible_collections/ds389/ansible_ds/playbooks/remove_backup_from_server.yml
+++ b/ansible_collections/ds389/ansible_ds/playbooks/remove_backup_from_server.yml
@@ -7,5 +7,5 @@
     ds389_backup_name: localhost_2022_05_19_21_25_05
 
   roles:
-  - role: ds389_backup
-    state: absent
+    - role: ds389_backup
+      state: absent

--- a/ansible_collections/ds389/ansible_ds/playbooks/restore_instance.yml
+++ b/ansible_collections/ds389/ansible_ds/playbooks/restore_instance.yml
@@ -7,5 +7,5 @@
     ds389_backup_name: localhost_2022_05_19_21_26_26
 
   roles:
-  - role: ds389_backup
-    state: restored
+    - role: ds389_backup
+      state: restored

--- a/ansible_collections/ds389/ansible_ds/playbooks/restore_instance_from_controller.yml
+++ b/ansible_collections/ds389/ansible_ds/playbooks/restore_instance_from_controller.yml
@@ -5,8 +5,8 @@
 
   vars:
     ds389_backup_name: localhost.localdomain_localhost_2022_05_19_21_25_05
-    ds389_backup_from_controller: yes
+    ds389_backup_from_controller: true
 
   roles:
-  - role: ds389_backup
-    state: restored
+    - role: ds389_backup
+      state: restored

--- a/ansible_collections/ds389/ansible_ds/playbooks/roles/ds389_backup/defaults/main.yml
+++ b/ansible_collections/ds389/ansible_ds/playbooks/roles/ds389_backup/defaults/main.yml
@@ -1,5 +1,5 @@
 ---
 # defaults file for ds389_backup
-ds389_backup_keep_on_server: no
-ds389_backup_to_controller: no
-ds389_backup_from_controller: no
+ds389_backup_keep_on_server: false
+ds389_backup_to_controller: false
+ds389_backup_from_controller: false

--- a/ansible_collections/ds389/ansible_ds/playbooks/roles/ds389_backup/meta/main.yml
+++ b/ansible_collections/ds389/ansible_ds/playbooks/roles/ds389_backup/meta/main.yml
@@ -5,15 +5,15 @@ galaxy_info:
   description: A role to backup and restore an DS instance
   company: Red Hat, Inc
   license: GPLv3
-  min_ansible_version: 2.9
+  min_ansible_version: "2.9"
   platforms:
-  - name: Fedora
-    versions:
-    - all
-  - name: EL
-    versions:
-    - 8
-    - 9
+    - name: Fedora
+      versions:
+        - all
+    - name: EL
+      versions:
+        - "8"
+        - "9"
   galaxy_tags:
     - linux
     - ds389

--- a/ansible_collections/ds389/ansible_ds/playbooks/roles/ds389_backup/tasks/backup.yml
+++ b/ansible_collections/ds389/ansible_ds/playbooks/roles/ds389_backup/tasks/backup.yml
@@ -1,46 +1,43 @@
 ---
 - name: Set name of the DS archive directory
-  set_fact:
+  ansible.builtin.set_fact:
     ds389_backup_archive_path: "localhost_{{ lookup('pipe', 'date +%Y_%m_%d_%H_%M_%S') }}"
   when: ds389_backup_archive_path is not defined
 
 - name: Stop DS instance, if started
-  service:
+  ansible.builtin.service:
     name: dirsrv@localhost
     state: stopped
 
 - name: Create backup
-  command:
-    argv:
-      - dsctl
-      - localhost
-      - db2bak
-      - "{{ ds389_backup_archive_path }}"
+  ansible.builtin.shell: >
+    dsctl
+    localhost
+    db2bak
+    {{ ds389_backup_archive_path }}
   register: result_ds389_backup
 
 - name: Fail to backup the instance
-  fail: msg="Failed to backup the instance"
+  ansible.builtin.fail:
+    msg: "Failed to backup the instance"
   when: item.find("db2bak successful") < 0
   with_items:
-  - "{{ result_ds389_backup.stdout }}"
+    - "{{ result_ds389_backup.stdout }}"
 
 - name: Start DS instance, if started
-  service:
+  ansible.builtin.service:
     name: dirsrv@localhost
     state: started
 
-- block:
-  - name: Copy backup to controller
-    import_tasks: "{{ role_path }}/tasks/copy_backup_from_server.yml"
-    vars:
-      ds389_backup_archive_path: "{{ ds389_backup_archive_path }}"
-    when: state|default("present") == "present"
-
-  - name: Remove backup on server
-    import_tasks: "{{ role_path }}/tasks/remove_backup_from_server.yml"
-    vars:
-      ds389_backup_item: "{{ ds389_backup_archive_path }}"
-    when: not ds389_backup_keep_on_server
-
+- name: Handle backup
   when: ds389_backup_to_controller
+  block:
+    - name: Copy backup to controller
+      ansible.builtin.import_tasks: "{{ role_path }}/tasks/copy_backup_from_server.yml"
+      when: state|default("present") == "present"
 
+    - name: Remove backup on server
+      ansible.builtin.import_tasks: "{{ role_path }}/tasks/remove_backup_from_server.yml"
+      vars:
+        ds389_backup_item: "{{ ds389_backup_archive_path }}"
+      when: not ds389_backup_keep_on_server

--- a/ansible_collections/ds389/ansible_ds/playbooks/roles/ds389_backup/tasks/copy_backup_from_server.yml
+++ b/ansible_collections/ds389/ansible_ds/playbooks/roles/ds389_backup/tasks/copy_backup_from_server.yml
@@ -1,47 +1,48 @@
 ---
 - name: Fail on invalid ds389_backup_archive_path
-  fail: msg="ds389_backup_archive_path {{ ds389_backup_archive_path }} is not valid"
+  ansible.builtin.fail:
+    msg: "ds389_backup_archive_path {{ ds389_backup_archive_path }} is not valid"
   when: ds389_backup_archive_path is not defined or
         ds389_backup_archive_path | length < 1
 
 - name: Set controller destination directory
-  set_fact:
+  ansible.builtin.set_fact:
     ds389_backup_controller_dir:
-        "{{ ds389_backup_archive_controller_path | default(lookup('env','PWD')) }}/{{
-         ds389_backup_archive_name_prefix | default(ansible_facts['fqdn']) }}_{{
-         ds389_backup_archive_path }}/"
+      "{{ ds389_backup_archive_controller_path | default(lookup('env', 'PWD')) }}/{{
+        ds389_backup_archive_name_prefix | default(ansible_facts['fqdn']) }}_{{ ds389_backup_archive_path }}/"
 
 - name: Get DS backup dir
-  import_tasks: "{{ role_path }}/tasks/get_ds389_backup_dir.yml"
+  ansible.builtin.import_tasks: "{{ role_path }}/tasks/get_ds389_backup_dir.yml"
 
 - name: Stat backup on server
-  stat:
+  ansible.builtin.stat:
     path: "{{ ds389_backup_dir }}/{{ ds389_backup_archive_path }}"
   register: result_backup_stat
 
 - name: Fail on missing backup directory
-  fail: msg="Unable to find backup {{ ds389_backup_archive_path }}"
+  ansible.builtin.fail:
+    msg: "Unable to find backup {{ ds389_backup_archive_path }}"
   when: result_backup_stat.stat.isdir is not defined
 
 - name: Get backup files to copy for "{{ ds389_backup_archive_path }}"
-  shell:
+  ansible.builtin.shell:
     find . -type f | cut -d"/" -f 2
   args:
     chdir: "{{ ds389_backup_dir }}/{{ ds389_backup_archive_path }}"
   register: result_find_backup_files
 
 - name: Copy server backup files to controller
-  fetch:
-    flat: yes
+  ansible.builtin.fetch:
+    flat: true
     src: "{{ ds389_backup_dir }}/{{ ds389_backup_archive_path }}/{{ item }}"
     dest: "{{ ds389_backup_controller_dir }}"
   with_items:
-  - "{{ result_find_backup_files.stdout_lines }}"
+    - "{{ result_find_backup_files.stdout_lines }}"
 
 - name: Fix file modes for backup on controller
-  file:
+  ansible.builtin.file:
     dest: "{{ ds389_backup_controller_dir }}"
     mode: u=rwX,go=
-    recurse: yes
+    recurse: true
   delegate_to: localhost
-  become: no
+  become: false

--- a/ansible_collections/ds389/ansible_ds/playbooks/roles/ds389_backup/tasks/copy_backup_to_server.yml
+++ b/ansible_collections/ds389/ansible_ds/playbooks/roles/ds389_backup/tasks/copy_backup_to_server.yml
@@ -1,34 +1,36 @@
 ---
 - name: Fail on invalid ds389_backup_archive_path
-  fail: msg="ds389_backup_archive_path {{ ds389_backup_archive_path }} is not valid"
+  ansible.builtin.fail:
+    msg: "ds389_backup_archive_path {{ ds389_backup_archive_path }} is not valid"
   when: ds389_backup_archive_path is not defined or
         ds389_backup_archive_path | length < 1
 
 - name: Set controller source directory
-  set_fact:
+  ansible.builtin.set_fact:
     ds389_backup_controller_dir:
-      "{{ ds389_backup_controller_path | default(lookup('env','PWD')) }}"
+      "{{ ds389_backup_controller_path | default(lookup('env', 'PWD')) }}"
 
 - name: Set ds389_backup_item
-  set_fact:
+  ansible.builtin.set_fact:
     ds389_backup_item: "{{ ds389_backup_archive_path }}"
 
 - name: Stat backup to copy
-  stat:
+  ansible.builtin.stat:
     path: "{{ ds389_backup_controller_dir }}/{{ ds389_backup_archive_path }}"
   register: result_backup_stat
   delegate_to: localhost
-  become: no
+  become: false
 
 - name: Fail on missing backup to copy
-  fail: msg="Unable to find backup {{ ds389_backup_archive_path }}"
+  ansible.builtin.fail:
+    msg: "Unable to find backup {{ ds389_backup_archive_path }}"
   when: result_backup_stat.stat.isdir is not defined
 
 - name: Get DS backup dir
-  import_tasks: "{{ role_path }}/tasks/get_ds389_backup_dir.yml"
+  ansible.builtin.import_tasks: "{{ role_path }}/tasks/get_ds389_backup_dir.yml"
 
 - name: Copy backup files to server for "{{ ds389_backup_item }}"
-  copy:
+  ansible.builtin.copy:
     src: "{{ ds389_backup_controller_dir }}/{{ ds389_backup_archive_path }}/"
     dest: "{{ ds389_backup_dir }}/{{ ds389_backup_item }}"
     owner: dirsrv

--- a/ansible_collections/ds389/ansible_ds/playbooks/roles/ds389_backup/tasks/get_ds389_backup_dir.yml
+++ b/ansible_collections/ds389/ansible_ds/playbooks/roles/ds389_backup/tasks/get_ds389_backup_dir.yml
@@ -6,7 +6,8 @@
       from lib389.paths import Paths
       print(Paths("localhost").backup_dir)
   register: result_lib389_backup_dir
+  changed_when: false
 
 - name: Set DS backup dir
-  set_fact:
+  ansible.builtin.set_fact:
     ds389_backup_dir: "{{ result_lib389_backup_dir.stdout_lines | first }}"

--- a/ansible_collections/ds389/ansible_ds/playbooks/roles/ds389_backup/tasks/main.yml
+++ b/ansible_collections/ds389/ansible_ds/playbooks/roles/ds389_backup/tasks/main.yml
@@ -2,125 +2,133 @@
 # tasks file for ipabackup
 
 - name: Check for empty vars
-  fail: msg="Variable {{ item }} is empty"
+  ansible.builtin.fail:
+    msg: "Variable {{ item }} is empty"
   when: "item in vars and not vars[item]"
   with_items: "{{ ds389_backup_empty_var_checks }}"
   vars:
     ds389_backup_empty_var_checks:
-#    - ds389_backup_instance
-    - ds389_backup_controller_path
-    - ds389_backup_name_prefix
+#     - ds389_backup_instance
+      - ds389_backup_controller_path
+      - ds389_backup_name_prefix
 
 - name: Fail if ds389_backup_from_controller and ds389_backup_to_controller are set
-  fail: msg="ds389_backup_from_controller and ds389_backup_to_controller are set"
+  ansible.builtin.fail:
+    msg: "ds389_backup_from_controller and ds389_backup_to_controller are set"
   when: ds389_backup_from_controller | bool and ds389_backup_to_controller | bool
 
 - name: Get ds389_backup_dir from DS installation
-  include_tasks: "{{ role_path }}/tasks/get_ds389_backup_dir.yml"
+  ansible.builtin.include_tasks: "{{ role_path }}/tasks/get_ds389_backup_dir.yml"
 
 - name: Backup DS server
-  include_tasks: "{{ role_path }}/tasks/backup.yml"
+  ansible.builtin.include_tasks: "{{ role_path }}/tasks/backup.yml"
   when: state|default("present") == "present"
 
 - name: Fail for given ds389_backup_name if state is not copied, restored or absent
-  fail: msg="ds389_backup_name is given and state is not copied, restored or absent"
+  ansible.builtin.fail:
+    msg: "ds389_backup_name is given and state is not copied, restored or absent"
   when: state is not defined or
         (state != "copied" and state != "restored" and state != "absent") and
         ds389_backup_name is defined
 
 - name: Fail on missing ds389_backup_name
-  fail: msg="ds389_backup_name is not set"
+  ansible.builtin.fail:
+    msg: "ds389_backup_name is not set"
   when: (ds389_backup_name is not defined or not ds389_backup_name) and
         state is defined and
         (state == "copied" or state == "restored" or state == "absent")
 
-- block:
-  - name: Get list of all backups on IPA server
-    shell:
-      ls -1
-    args:
-      chdir: "{{ ds389_backup_dir }}/"
-    register: result_backup_find_backup_files
-
-  - name: Set ds389_backup_names using backup list
-    set_fact:
-      ds389_backup_names: "{{ result_backup_find_backup_files.stdout_lines }}"
-
+- name: Get all backup names for copy to controller
   when: state is defined and
         ((state == "copied" and ds389_backup_to_controller) or
          state == "absent") and
         ds389_backup_name is defined and ds389_backup_name == "all"
+  block:
+    - name: Get list of all backups on 389 DS server
+      ansible.builtin.shell:
+        ls -1
+      args:
+        chdir: "{{ ds389_backup_dir }}/"
+      register: result_backup_find_backup_files
+      changed_when: false
 
-- block:
-  - name: Fail on ds389_backup_name all
-    fail: msg="ds389_backup_name can not be all in this case"
-    when: ds389_backup_name is defined and ds389_backup_name == "all"
+    - name: Set ds389_backup_names using backup list
+      ansible.builtin.set_fact:
+        ds389_backup_names: "{{ result_backup_find_backup_files.stdout_lines }}"
 
-  - name: Set ds389_backup_names from ds389_backup_name string
-    set_fact:
-      ds389_backup_names: ["{{ ds389_backup_name }}"]
-    when: ds389_backup_name | type_debug != "list"
-
-  - name: Set ds389_backup_names from ds389_backup_name list
-    set_fact:
-      ds389_backup_names: "{{ ds389_backup_name }}"
-    when: ds389_backup_name | type_debug == "list"
+- name: Set ds389_backup_names from ds389_backup_name
   when: ds389_backup_names is not defined and ds389_backup_name is defined
+  block:
+    - name: Fail on ds389_backup_name all
+      ansible.builtin.fail:
+        msg: "ds389_backup_name can not be all in this case"
+      when: ds389_backup_name is defined and ds389_backup_name == "all"
+
+    - name: Set ds389_backup_names from ds389_backup_name string
+      ansible.builtin.set_fact:
+        ds389_backup_names: ["{{ ds389_backup_name }}"]
+      when: ds389_backup_name | type_debug != "list"
+
+    - name: Set ds389_backup_names from ds389_backup_name list
+      ansible.builtin.set_fact:
+        ds389_backup_names: "{{ ds389_backup_name }}"
+      when: ds389_backup_name | type_debug == "list"
 
 - name: Set empty ds389_backup_names if ds389_backup_name is not defined
-  set_fact:
+  ansible.builtin.set_fact:
     ds389_backup_names: []
   when: ds389_backup_names is not defined and ds389_backup_name is not defined
 
-- block:
-  - name: Copy backup from DS server
-    include_tasks: "{{ role_path }}/tasks/copy_backup_from_server.yml"
-    vars:
-      ds389_backup_archive_path: "{{ main_item }}"
-    with_items:
-    - "{{ ds389_backup_names }}"
-    loop_control:
-      loop_var: main_item
-    when: state is defined and state == "copied"
-
-  - name: Remove backup from DS server
-    include_tasks: "{{ role_path }}/tasks/remove_backup_from_server.yml"
-    vars:
-      ds389_backup_item: "{{ main_item }}"
-    with_items:
-    - "{{ ds389_backup_names }}"
-    loop_control:
-      loop_var: main_item
-    when: state is defined and state == "absent"
-
+- name: Process "{{ ds389_backup_names }}"
   when: state is defined and
         ((state == "copied" and ds389_backup_to_controller) or state == "absent")
+  block:
+    - name: Copy backup from DS server
+      ansible.builtin.include_tasks: "{{ role_path }}/tasks/copy_backup_from_server.yml"
+      vars:
+        ds389_backup_archive_path: "{{ main_item }}"
+      with_items:
+        - "{{ ds389_backup_names }}"
+      loop_control:
+        loop_var: main_item
+      when: state is defined and state == "copied"
+
+    - name: Remove backup from DS server
+      ansible.builtin.include_tasks: "{{ role_path }}/tasks/remove_backup_from_server.yml"
+      vars:
+        ds389_backup_item: "{{ main_item }}"
+      with_items:
+        - "{{ ds389_backup_names }}"
+      loop_control:
+        loop_var: main_item
+      when: state is defined and state == "absent"
 
 # Fail with more than one entry in ds389_backup_names for copy to sever and
 # restore.
 
 - name: Fail to copy or restore more than one backup on the server
-  fail: msg="Only one backup can be copied to the server or restored"
+  ansible.builtin.fail:
+    msg: "Only one backup can be copied to the server or restored"
   when: state is defined and (state == "copied" or state == "restored") and
         ds389_backup_from_controller | bool and ds389_backup_names | length != 1
 
 # Use only first item in ds389_backup_names for copy to server and for restore.
 
-- block:
-  - name: Copy backup to server
-    include_tasks: "{{ role_path }}/tasks/copy_backup_to_server.yml"
-
-  - name: Restore DS server backup
-    include_tasks: "{{ role_path }}/tasks/restore.yml"
-    when: state|default("present") == "restored"
-
-  vars:
-    ds389_backup_archive_path: "{{ ds389_backup_names[0] }}"
+- name: Process "{{ ds389_backup_names[0] }}"
   when: ds389_backup_from_controller or
         (state|default("present") == "copied" and not ds389_backup_to_controller)
+  vars:
+    ds389_backup_archive_path: "{{ ds389_backup_names[0] }}"
+  block:
+    - name: Copy backup to server
+      ansible.builtin.include_tasks: "{{ role_path }}/tasks/copy_backup_to_server.yml"
+
+    - name: Restore DS server backup
+      ansible.builtin.include_tasks: "{{ role_path }}/tasks/restore.yml"
+      when: state|default("present") == "restored"
 
 - name: Restore DS server
-  include_tasks: "{{ role_path }}/tasks/restore.yml"
+  ansible.builtin.include_tasks: "{{ role_path }}/tasks/restore.yml"
   vars:
     ds389_backup_item: "{{ ds389_backup_names[0] | basename }}"
   when: not ds389_backup_from_controller and

--- a/ansible_collections/ds389/ansible_ds/playbooks/roles/ds389_backup/tasks/remove_backup_from_server.yml
+++ b/ansible_collections/ds389/ansible_ds/playbooks/roles/ds389_backup/tasks/remove_backup_from_server.yml
@@ -1,5 +1,5 @@
 ---
 - name: Remove backup "{{ ds389_backup_item }}"
-  file:
+  ansible.builtin.file:
     path: "{{ ds389_backup_dir }}/{{ ds389_backup_item }}"
     state: absent

--- a/ansible_collections/ds389/ansible_ds/playbooks/roles/ds389_backup/tasks/restore.yml
+++ b/ansible_collections/ds389/ansible_ds/playbooks/roles/ds389_backup/tasks/restore.yml
@@ -1,33 +1,34 @@
 ---
 - name: Get DS backup dir
-  import_tasks: "{{ role_path }}/tasks/get_ds389_backup_dir.yml"
+  ansible.builtin.import_tasks: "{{ role_path }}/tasks/get_ds389_backup_dir.yml"
 
 - name: Stat backup on server
-  stat:
+  ansible.builtin.stat:
     path: "{{ ds389_backup_dir }}/{{ ds389_backup_item }}"
   register: result_backup_stat
 
 - name: Fail on missing backup directory
-  fail: msg="Unable to find backup {{ ds389_backup_item }}"
+  ansible.builtin.fail:
+    msg: "Unable to find backup {{ ds389_backup_item }}"
   when: result_backup_stat.stat.isdir is not defined
 
 - name: Stop DS instance, if started
-  service:
+  ansible.builtin.service:
     name: dirsrv@localhost
     state: stopped
 
 - name: Restore backup
-  command:
+  ansible.builtin.command:
     argv:
       - dsctl
       - localhost
       - bak2db
       - "{{ ds389_backup_item }}"
   register: result_dsrestore
-  ignore_errors: yes
+  ignore_errors: true
 
 - name: Report error for restore operation
-  debug:
+  ansible.builtin.debug:
     msg: "{{ result_dsrestore.stderr }}"
   when: result_dsrestore is failed
-  failed_when: yes
+  failed_when: true


### PR DESCRIPTION
Description: Address the issues in the existing backup role and playbooks. Add .ansible-lint file and except command/shell-related errors as they are not relevant to the way we do things.

Relates: https://github.com/389ds/ansible-ds/issues/28

Reviewed by: ?