### PR TITLE
Issue 39 - Set minimal permissions on GitHub Workflows

### DIFF
--- a/.github/workflows/anlint.yml
+++ b/.github/workflows/anlint.yml
@@ -1,6 +1,10 @@
 name: Ansible lint
 on: [push, pull_request]
 
+permissions: 
+  contents: read
+  actions: read
+
 jobs:
   ansible_lint:
     runs-on: ubuntu-latest

--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -1,6 +1,10 @@
 name: Python lint
 on: [push, pull_request]
 
+permissions: 
+  contents: read
+  actions: read
+
 jobs:
   python_lint:
     runs-on: ubuntu-latest

--- a/.github/workflows/utest.yml
+++ b/.github/workflows/utest.yml
@@ -16,6 +16,9 @@ on:
         required: false
         default: false
 
+permissions: 
+  contents: read
+  actions: read
 
 jobs:
   build:


### PR DESCRIPTION
Defining minimal permissions secures you against erroneous or malicious behavior from external jobs you call from your workflow. It's especially important in case they get compromised.

Fixes: https://github.com/389ds/ansible-ds/issues/39

Reviewed by: ?