### PR TITLE
Issue 28 - Fix ansible-lint issues

### DIFF
--- a/.ansible-lint
+++ b/.ansible-lint
@@ -3,7 +3,8 @@ exclude_paths:
   - .github/
   - .pylintrc
   - utils/
-  - '*/testds389_vault.yaml'
+  - ansible_collections/ds389/ansible_ds/tests/inventory/basic/inventory/testds389_vault.yaml
+  - ansible_collections/ds389/ansible_ds/tests/inventory/replication/inventory/testds389_vault.yaml
 
 parseable: true
 quiet: false

--- a/ansible_collections/ds389/ansible_ds/playbooks/roles/ds389_backup/tasks/backup.yml
+++ b/ansible_collections/ds389/ansible_ds/playbooks/roles/ds389_backup/tasks/backup.yml
@@ -15,14 +15,14 @@
     localhost
     db2bak
     {{ ds389_backup_archive_path }}
-  register: result_ds389_backup
+  register: ds389_backup_result
 
 - name: Fail to backup the instance
   ansible.builtin.fail:
     msg: "Failed to backup the instance"
   when: item.find("db2bak successful") < 0
   with_items:
-    - "{{ result_ds389_backup.stdout }}"
+    - "{{ ds389_backup_result.stdout }}"
 
 - name: Start DS instance, if started
   ansible.builtin.service:

--- a/ansible_collections/ds389/ansible_ds/playbooks/roles/ds389_backup/tasks/copy_backup_from_server.yml
+++ b/ansible_collections/ds389/ansible_ds/playbooks/roles/ds389_backup/tasks/copy_backup_from_server.yml
@@ -17,19 +17,19 @@
 - name: Stat backup on server
   ansible.builtin.stat:
     path: "{{ ds389_backup_dir }}/{{ ds389_backup_archive_path }}"
-  register: result_backup_stat
+  register: ds389_backup_stat_result
 
 - name: Fail on missing backup directory
   ansible.builtin.fail:
     msg: "Unable to find backup {{ ds389_backup_archive_path }}"
-  when: result_backup_stat.stat.isdir is not defined
+  when: ds389_backup_stat_result.stat.isdir is not defined
 
 - name: Get backup files to copy for "{{ ds389_backup_archive_path }}"
   ansible.builtin.shell:
     find . -type f | cut -d"/" -f 2
   args:
     chdir: "{{ ds389_backup_dir }}/{{ ds389_backup_archive_path }}"
-  register: result_find_backup_files
+  register: ds389_backup_find_backup_files_result
 
 - name: Copy server backup files to controller
   ansible.builtin.fetch:
@@ -37,7 +37,7 @@
     src: "{{ ds389_backup_dir }}/{{ ds389_backup_archive_path }}/{{ item }}"
     dest: "{{ ds389_backup_controller_dir }}"
   with_items:
-    - "{{ result_find_backup_files.stdout_lines }}"
+    - "{{ ds389_backup_find_backup_files_result.stdout_lines }}"
 
 - name: Fix file modes for backup on controller
   ansible.builtin.file:

--- a/ansible_collections/ds389/ansible_ds/playbooks/roles/ds389_backup/tasks/copy_backup_to_server.yml
+++ b/ansible_collections/ds389/ansible_ds/playbooks/roles/ds389_backup/tasks/copy_backup_to_server.yml
@@ -17,14 +17,14 @@
 - name: Stat backup to copy
   ansible.builtin.stat:
     path: "{{ ds389_backup_controller_dir }}/{{ ds389_backup_archive_path }}"
-  register: result_backup_stat
+  register: ds389_backup_stat_result
   delegate_to: localhost
   become: false
 
 - name: Fail on missing backup to copy
   ansible.builtin.fail:
     msg: "Unable to find backup {{ ds389_backup_archive_path }}"
-  when: result_backup_stat.stat.isdir is not defined
+  when: ds389_backup_stat_result.stat.isdir is not defined
 
 - name: Get DS backup dir
   ansible.builtin.import_tasks: "{{ role_path }}/tasks/get_ds389_backup_dir.yml"

--- a/ansible_collections/ds389/ansible_ds/playbooks/roles/ds389_backup/tasks/get_ds389_backup_dir.yml
+++ b/ansible_collections/ds389/ansible_ds/playbooks/roles/ds389_backup/tasks/get_ds389_backup_dir.yml
@@ -5,9 +5,9 @@
     stdin: |
       from lib389.paths import Paths
       print(Paths("localhost").backup_dir)
-  register: result_lib389_backup_dir
+  register: ds389_backup_dir_result
   changed_when: false
 
 - name: Set DS backup dir
   ansible.builtin.set_fact:
-    ds389_backup_dir: "{{ result_lib389_backup_dir.stdout_lines | first }}"
+    ds389_backup_dir: "{{ ds389_backup_dir_result.stdout_lines | first }}"

--- a/ansible_collections/ds389/ansible_ds/playbooks/roles/ds389_backup/tasks/main.yml
+++ b/ansible_collections/ds389/ansible_ds/playbooks/roles/ds389_backup/tasks/main.yml
@@ -49,12 +49,12 @@
         ls -1
       args:
         chdir: "{{ ds389_backup_dir }}/"
-      register: result_backup_find_backup_files
+      register: ds389_backup_find_backup_files_result
       changed_when: false
 
     - name: Set ds389_backup_names using backup list
       ansible.builtin.set_fact:
-        ds389_backup_names: "{{ result_backup_find_backup_files.stdout_lines }}"
+        ds389_backup_names: "{{ ds389_backup_find_backup_files_result.stdout_lines }}"
 
 - name: Set ds389_backup_names from ds389_backup_name
   when: ds389_backup_names is not defined and ds389_backup_name is defined

--- a/ansible_collections/ds389/ansible_ds/playbooks/roles/ds389_backup/tasks/restore.yml
+++ b/ansible_collections/ds389/ansible_ds/playbooks/roles/ds389_backup/tasks/restore.yml
@@ -5,12 +5,12 @@
 - name: Stat backup on server
   ansible.builtin.stat:
     path: "{{ ds389_backup_dir }}/{{ ds389_backup_item }}"
-  register: result_backup_stat
+  register: ds389_backup_stat_result
 
 - name: Fail on missing backup directory
   ansible.builtin.fail:
     msg: "Unable to find backup {{ ds389_backup_item }}"
-  when: result_backup_stat.stat.isdir is not defined
+  when: ds389_backup_stat_result.stat.isdir is not defined
 
 - name: Stop DS instance, if started
   ansible.builtin.service:
@@ -24,11 +24,11 @@
       - localhost
       - bak2db
       - "{{ ds389_backup_item }}"
-  register: result_dsrestore
+  register: ds389_backup_dsrestore_result
   ignore_errors: true
 
 - name: Report error for restore operation
   ansible.builtin.debug:
-    msg: "{{ result_dsrestore.stderr }}"
-  when: result_dsrestore is failed
+    msg: "{{ ds389_backup_dsrestore_result.stderr }}"
+  when: ds389_backup_dsrestore_result is failed
   failed_when: true


### PR DESCRIPTION
Description: Rename variables so it has the role in the name.
And specify the exclude path for the lint as Ansible doesn't
process wildcards correctly as of now.

Relates: https://github.com/389ds/ansible-ds/issues/28

Reviewed by: ?